### PR TITLE
Add "using" method in model queryset manager, which will be used to change database at runtime while querying.

### DIFF
--- a/docs/queries.md
+++ b/docs/queries.md
@@ -147,6 +147,16 @@ users = await User.objects.filter(id__desc=False) # same as asc True
 users = await User.objects.filter(id__neq=1) # same as asc True
 ```
 
+### Using
+
+Change the database while querying, only need to supply the database name in order to change the database.
+
+=== "Manager"
+
+    ```python
+    users = await User.objects.using("my_mongo_db").all()
+    ```
+
 ### Query
 
 The `query` is what is used by the `queryset` instead of the `manager`. In other words, the `query`

--- a/mongoz/core/db/documents/document.py
+++ b/mongoz/core/db/documents/document.py
@@ -21,7 +21,7 @@ class Document(DocumentRow):
     Representation of an Mongoz Document.
     """
 
-    async def create(self: "Document", collection: AsyncIOMotorCollection = None) -> "Document":
+    async def create(self: "Document", collection: AsyncIOMotorCollection = None) -> "Document":  # type: ignore
         """
         Inserts a document.
         """

--- a/mongoz/core/db/documents/document.py
+++ b/mongoz/core/db/documents/document.py
@@ -3,6 +3,7 @@ from typing import Any, ClassVar, List, Mapping, Type, TypeVar, Union, cast
 import bson
 import pydantic
 from bson.errors import InvalidId
+from motor.motor_asyncio import AsyncIOMotorCollection
 from pydantic import BaseModel
 
 from mongoz.core.db.documents.document_row import DocumentRow
@@ -10,8 +11,6 @@ from mongoz.core.db.documents.metaclasses import EmbeddedModelMetaClass
 from mongoz.core.db.fields.base import MongozField
 from mongoz.exceptions import InvalidKeyError
 from mongoz.utils.mixins import is_operation_allowed
-
-from motor.motor_asyncio import AsyncIOMotorCollection
 
 T = TypeVar("T", bound="Document")
 
@@ -21,7 +20,7 @@ class Document(DocumentRow):
     Representation of an Mongoz Document.
     """
 
-    async def create(self: "Document", collection: AsyncIOMotorCollection = None) -> "Document":  # type: ignore
+    async def create(self: "Document", collection: Union[AsyncIOMotorCollection, None] = None) -> "Document":  # type: ignore
         """
         Inserts a document.
         """

--- a/mongoz/core/db/documents/document.py
+++ b/mongoz/core/db/documents/document.py
@@ -30,7 +30,7 @@ class Document(DocumentRow):
         await self.signals.pre_save.send(sender=self.__class__, instance=self)
 
         data = self.model_dump(exclude={"id"})
-        if collection:
+        if collection is not None:
             result = await collection.insert_one(data)  # type: ignore
         else:
             result = await self.meta.collection._collection.insert_one(data)  # type: ignore

--- a/mongoz/core/db/querysets/core/manager.py
+++ b/mongoz/core/db/querysets/core/manager.py
@@ -65,7 +65,7 @@ class Manager(QuerySetProtocol, AwaitableQuery[MongozDocument]):
     def __get__(self, instance: Any, owner: Any) -> "Manager":
         return self.__class__(model_class=owner)
 
-    def using(self, database_name: str):
+    def using(self, database_name: str) -> "Manager":
         """
             **Type** Public
 
@@ -87,7 +87,7 @@ class Manager(QuerySetProtocol, AwaitableQuery[MongozDocument]):
                     self._collection.name
                 - return the self instance.
         """
-        database = self.model_class.meta.registry.get_database(database_name)
+        database = self.model_class.meta.registry.get_database(database_name) # type: ignore
         self._collection = database.get_collection(
             self._collection.name)._collection
         return self

--- a/mongoz/core/db/querysets/core/manager.py
+++ b/mongoz/core/db/querysets/core/manager.py
@@ -87,9 +87,8 @@ class Manager(QuerySetProtocol, AwaitableQuery[MongozDocument]):
                     self._collection.name
                 - return the self instance.
         """
-        database = self.model_class.meta.registry.get_database(database_name) # type: ignore
-        self._collection = database.get_collection(
-            self._collection.name)._collection
+        database = self.model_class.meta.registry.get_database(database_name)  # type: ignore
+        self._collection = database.get_collection(self._collection.name)._collection
         return self
 
     def clone(self) -> Any:

--- a/mongoz/core/db/querysets/core/manager.py
+++ b/mongoz/core/db/querysets/core/manager.py
@@ -65,6 +65,33 @@ class Manager(QuerySetProtocol, AwaitableQuery[MongozDocument]):
     def __get__(self, instance: Any, owner: Any) -> "Manager":
         return self.__class__(model_class=owner)
 
+    def using(self, database_name: str):
+        """
+            **Type** Public
+
+            **Arguments:**
+                - database_name (str): string contains the database name.
+
+            **Returns:**
+                - Object: self instance.
+
+            **Raises:**
+                - None
+
+            This method is use to select the database:
+                - get the data base using the get_database method form the meta \
+                    class registry using the database_name that provided in \
+                        argument.
+                - store the database object as database.
+                - get the collection from the data base based on \
+                    self._collection.name
+                - return the self instance.
+        """
+        database = self.model_class.meta.registry.get_database(database_name)
+        self._collection = database.get_collection(
+            self._collection.name)._collection
+        return self
+
     def clone(self) -> Any:
         manager = self.__class__.__new__(self.__class__)
         manager.model_class = self.model_class
@@ -196,7 +223,7 @@ class Manager(QuerySetProtocol, AwaitableQuery[MongozDocument]):
             else:
                 filter_clauses += clauses
 
-        return cast(
+        manager = cast(
             "Manager",
             self.__class__(
                 model_class=self.model_class,
@@ -206,6 +233,8 @@ class Manager(QuerySetProtocol, AwaitableQuery[MongozDocument]):
                 defer_fields=self._defer_fields,
             ),
         )
+        manager._collection = self._collection
+        return manager
 
     def filter(self, **kwargs: Any) -> "Manager":
         """
@@ -355,7 +384,7 @@ class Manager(QuerySetProtocol, AwaitableQuery[MongozDocument]):
         Creates a mongo db document.
         """
         manager: "Manager" = self.clone()
-        instance = await manager.model_class(**kwargs).create()
+        instance = await manager.model_class(**kwargs).create(manager._collection)
         return cast("Document", instance)
 
     async def delete(self) -> int:

--- a/tests/models/manager/test_using.py
+++ b/tests/models/manager/test_using.py
@@ -6,7 +6,7 @@ from tests.conftest import client
 
 import mongoz
 from mongoz import Document, ObjectId
-from mongoz.exceptions import DocumentNotFound, MultipleDocumentsReturned
+from mongoz.exceptions import DocumentNotFound
 
 pytestmark = pytest.mark.anyio
 pydantic_version = pydantic.__version__[:3]

--- a/tests/models/manager/test_using.py
+++ b/tests/models/manager/test_using.py
@@ -2,11 +2,11 @@ from typing import List, Optional
 
 import pydantic
 import pytest
-from tests.conftest import client
 
 import mongoz
 from mongoz import Document, ObjectId
 from mongoz.exceptions import DocumentNotFound
+from tests.conftest import client
 
 pytestmark = pytest.mark.anyio
 pydantic_version = pydantic.__version__[:3]
@@ -25,20 +25,20 @@ class Movie(Document):
 
 async def test_model_using() -> None:
     await Movie.objects.create(name="Harshali", year=2024)
-    await Movie.objects.using('test_my_db').create(name="Harshali Zode", year=2024)
+    await Movie.objects.using("test_my_db").create(name="Harshali Zode", year=2024)
 
     movie = await Movie.objects.get()
     assert movie.name == "Harshali"
 
-    movie = await Movie.objects.using('test_my_db').get()
+    movie = await Movie.objects.using("test_my_db").get()
     assert movie.name == "Harshali Zode"
 
-    movie = await Movie.objects.using('test_my_db').filter(name="Harshali Zode").get()
+    movie = await Movie.objects.using("test_my_db").filter(name="Harshali Zode").get()
     assert movie.name == "Harshali Zode"
 
-    movie = await Movie.objects.using('test_my_db').filter(_id=movie.id).get()
+    movie = await Movie.objects.using("test_my_db").filter(_id=movie.id).get()
     assert movie.name == "Harshali Zode"
 
     with pytest.raises(DocumentNotFound):
         await Movie.objects.filter(name="Harshali Zode").get()
-        await Movie.objects.using('test_my_db').filter(name="Harshali").get()
+        await Movie.objects.using("test_my_db").filter(name="Harshali").get()

--- a/tests/models/manager/test_using.py
+++ b/tests/models/manager/test_using.py
@@ -1,0 +1,44 @@
+from typing import List, Optional
+
+import pydantic
+import pytest
+from tests.conftest import client
+
+import mongoz
+from mongoz import Document, ObjectId
+from mongoz.exceptions import DocumentNotFound, MultipleDocumentsReturned
+
+pytestmark = pytest.mark.anyio
+pydantic_version = pydantic.__version__[:3]
+
+
+class Movie(Document):
+    name: str = mongoz.String()
+    year: int = mongoz.Integer()
+    tags: Optional[List[str]] = mongoz.Array(str, null=True)
+    uuid: Optional[ObjectId] = mongoz.ObjectId(null=True)
+
+    class Meta:
+        registry = client
+        database = "test_db"
+
+
+async def test_model_using() -> None:
+    await Movie.objects.create(name="Harshali", year=2024)
+    await Movie.objects.using('test_my_db').create(name="Harshali Zode", year=2024)
+
+    movie = await Movie.objects.get()
+    assert movie.name == "Harshali"
+
+    movie = await Movie.objects.using('test_my_db').get()
+    assert movie.name == "Harshali Zode"
+
+    movie = await Movie.objects.using('test_my_db').filter(name="Harshali Zode").get()
+    assert movie.name == "Harshali Zode"
+
+    movie = await Movie.objects.using('test_my_db').filter(_id=movie.id).get()
+    assert movie.name == "Harshali Zode"
+
+    with pytest.raises(DocumentNotFound):
+        await Movie.objects.filter(name="Harshali Zode").get()
+        await Movie.objects.using('test_my_db').filter(name="Harshali").get()


### PR DESCRIPTION
The "using" method allows us to change the database at runtime while querying. If the user does not use the "using" method, it behaviour the same as before; however, I have included logic to change the database during runtime.

It is compatible with create, get, all, filter, with the exception of the update query, which needs to be modified in order to be used with the "using" method because it creates duplicate documents with the updated one.

We can use the "using" method as follows:

`User.objects.using("DB_NAME").all()`